### PR TITLE
feat: detect edge case of 'maximum retries failed error' and display error message to the user

### DIFF
--- a/app/src/main/java/tk/therealsuji/vtopchennai/services/VTOPService.java
+++ b/app/src/main/java/tk/therealsuji/vtopchennai/services/VTOPService.java
@@ -483,11 +483,11 @@ public class VTOPService extends Service {
                             "                response.error_message = 'Your Account is Locked';" +
                             "                response.error_code = 4;" +
                             "            } else if(pageContent.includes('maximum fail attempts reached')) {" +
-                            "                response.error_message = 'Maximum Login attempts reached. Open VTOP on your browser to reset password';" +
-                            "                response.error_code = 6;" +
+                            "                response.error_message = 'Maximum login attempts reached, open VTOP in your browser to reset password';" +
+                            "                response.error_code = 5;" +
                             "            } else {" +
                             "                response.error_message = 'Unknown error';" +
-                            "                response.error_code = 5;" +
+                            "                response.error_code = 6;" +
                             "            }" +
                             "        }" +
                             "    }" +

--- a/app/src/main/java/tk/therealsuji/vtopchennai/services/VTOPService.java
+++ b/app/src/main/java/tk/therealsuji/vtopchennai/services/VTOPService.java
@@ -482,6 +482,9 @@ public class VTOPService extends Service {
                             "            } else if(pageContent.includes('your account is locked')) {" +
                             "                response.error_message = 'Your Account is Locked';" +
                             "                response.error_code = 4;" +
+                            "            } else if(pageContent.includes('maximum fail attempts reached')) {" +
+                            "                response.error_message = 'Maximum Login attempts reached. Open VTOP on your browser to reset password';" +
+                            "                response.error_code = 6;" +
                             "            } else {" +
                             "                response.error_message = 'Unknown error';" +
                             "                response.error_code = 5;" +


### PR DESCRIPTION
there is an edge case where the user tries to enter the wrong password multiple times and VTOP
might prevent you from signing in with the same password until it is resetted. We should
show this error message to the user and let the user know that they should stop trying and reset
the passwod from the VTOP web app before continuing to use the app
