### PR TITLE
fix: resolved data sync error 201 - no value for semesters

### DIFF
--- a/app/src/main/java/tk/therealsuji/vtopchennai/services/VTOPService.java
+++ b/app/src/main/java/tk/therealsuji/vtopchennai/services/VTOPService.java
@@ -164,7 +164,7 @@ public class VTOPService extends Service {
         this.webView = new WebView(getApplicationContext());
         this.webView.addJavascriptInterface(this, "Android");
         this.webView.getSettings().setJavaScriptEnabled(true);
-        this.webView.getSettings().setUserAgentString("Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.99 Mobile Safari/537.36");
+        this.webView.getSettings().setUserAgentString("Mozilla/5.0 (Android 14; Mobile; rv:123.0) Gecko/123.0 Firefox/123.0");
         this.webView.setBackgroundColor(Color.TRANSPARENT);
         this.webView.setHorizontalScrollBarEnabled(false);
         this.webView.setVerticalScrollBarEnabled(false);


### PR DESCRIPTION
Addresses issue #105 by updating the older user-agent to a newer one (`Mozilla/5.0 (Android 14; Mobile; rv:123.0) Gecko/123.0 Firefox/123.0`) in `services/VTOPService.java`.

Tested it out on a virtual android 14.0 emulator, and my android 13.0 phone too. It resolved the issue and works fine in both.