### PR TITLE
Display overall score and total weightage as decimals

### DIFF
--- a/app/src/main/java/tk/therealsuji/vtopchennai/widgets/PerformanceCard.java
+++ b/app/src/main/java/tk/therealsuji/vtopchennai/widgets/PerformanceCard.java
@@ -21,6 +21,8 @@ import tk.therealsuji.vtopchennai.R;
 import tk.therealsuji.vtopchennai.animations.AlphaAnimation;
 import tk.therealsuji.vtopchennai.animations.ResizeAnimation;
 
+import java.text.DecimalFormat;
+
 public class PerformanceCard extends LinearLayout {
     AppCompatTextView title, scoreText;
     Context context;
@@ -137,13 +139,12 @@ public class PerformanceCard extends LinearLayout {
     }
 
     public void setScore(Double score, Double max) {
-        score = Math.ceil(score);
         max = Math.ceil(max);
 
         this.scoreProgress.setProgress(score.intValue(), true);
         this.scoreProgress.setSecondaryProgress(max.intValue());
 
-        String scoreText = (max >= 100) ? score.intValue() + "%" : score.intValue() + "/" + max.intValue();
+        String scoreText = (max >= 100) ? new DecimalFormat("#.#").format(score) + "%" : new DecimalFormat("#.#").format(score) + "/" + max.intValue();
         this.scoreText.setText(scoreText);
     }
 


### PR DESCRIPTION
i think the overall score and the overall weightage scores of all the courses were better represented as decimal values at least upto single decimal place. 
![signal-2024-11-28-164711_002](https://github.com/user-attachments/assets/541d5564-8199-4105-8a5b-9f913f8ef694)
![signal-2024-11-28-164711_003](https://github.com/user-attachments/assets/bcd8f17f-f722-485f-be25-d97427a4f5ef)
